### PR TITLE
Added version key to manifest.json

### DIFF
--- a/custom_components/islamic_prayer_times/manifest.json
+++ b/custom_components/islamic_prayer_times/manifest.json
@@ -3,5 +3,6 @@
   "name": "Islamic Prayer Times",
   "documentation": "https://www.home-assistant.io/integrations/islamic_prayer_times",
   "codeowners": ["@engrbm87"],
-  "config_flow": true
+  "config_flow": true,
+  "version": "1.0.0"
 }


### PR DESCRIPTION
the version key is required from HA 2021.6, so added that in. Prayer Times Integration would not start without it.